### PR TITLE
Add dual language support

### DIFF
--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -42,6 +42,10 @@ class PlacesController < ApplicationController
   private
 
   def place_params
-    params.require(:place).permit(:name, :description, :category)
+    params.require(:place).permit(:en_name,
+                                  :es_name,
+                                  :en_description,
+                                  :es_description,
+                                  :category)
   end
 end

--- a/app/views/places/_form.html.erb
+++ b/app/views/places/_form.html.erb
@@ -1,12 +1,22 @@
 <%= form_with(model: @place, local: true) do |f| %>
   <div class="field">
-    <%= f.label :name %>
-    <%= f.text_field :name %>
+    <%= f.label :en_name %>
+    <%= f.text_field :en_name %>
   </div>
 
   <div class="field">
-    <%= f.label :description %>
-    <%= f.text_area :description %>
+    <%= f.label :es_name %>
+    <%= f.text_field :es_name %>
+  </div>
+
+  <div class="field">
+    <%= f.label :en_description %>
+    <%= f.text_area :en_description %>
+  </div class="field">
+
+  <div class="field">
+    <%= f.label :es_description %>
+    <%= f.text_area :es_description %>
   </div class="field">
 
   <div class="field">

--- a/app/views/places/index.html.erb
+++ b/app/views/places/index.html.erb
@@ -11,8 +11,8 @@
   <tbody>
     <% @places.each do |place| %>
       <tr>
-        <td><%= place.name %></td>
-        <td><%= place.description %></td>
+        <td><%= place.en_name %></td>
+        <td><%= place.en_description %></td>
         <td><%= place.category %></td>
         <td><%= link_to 'Show', place %></td>
         <td><%= link_to 'Edit', edit_place_path(place) %></td>

--- a/app/views/places/show.html.erb
+++ b/app/views/places/show.html.erb
@@ -1,13 +1,23 @@
 <p id="notice"><%= notice %></p>
 
 <p>
-  <strong>Name:</strong>
-  <%= @place.name %>
+  <strong>En Name:</strong>
+  <%= @place.en_name %>
+</p>
+
+<p>
+  <strong>Es Name:</strong>
+  <%= @place.es_name %>
 </p>
 
 <p>
   <strong>Description:</strong>
-  <%= @place.description %>
+  <%= @place.en_description %>
+</p>
+
+<p>
+  <strong>Description:</strong>
+  <%= @place.es_description %>
 </p>
 
 <p>

--- a/db/migrate/20200921144808_add_dual_language_support.rb
+++ b/db/migrate/20200921144808_add_dual_language_support.rb
@@ -1,0 +1,8 @@
+class AddDualLanguageSupport < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :places, :name, :en_name
+    rename_column :places, :description, :en_description
+    add_column :places, :es_name, :string
+    add_column :places, :es_description, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_10_152721) do
+ActiveRecord::Schema.define(version: 2020_09_21_144808) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "places", force: :cascade do |t|
-    t.string "name"
-    t.text "description"
+    t.string "en_name"
+    t.text "en_description"
     t.string "category"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "es_name"
+    t.string "es_description"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Prefix `places`  columns with `en` and `es` to represent language.
JSON representation could then come across the request with all information, allowing us to switch language on the client side.